### PR TITLE
Fix incorrect sidebar highlight 

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -410,7 +410,7 @@ Eve:`;
         <SideBar
           sidebarVisible={sidebarVisible}
           setSidebarVisible={setSidebarVisible}
-          activeLink={7}
+          activeLink={8}
         />
       </div>
       {width > 816 && (

--- a/src/components/Consultations.jsx
+++ b/src/components/Consultations.jsx
@@ -825,7 +825,7 @@ export function Consultations() {
       <SideBar
         sidebarVisible={sidebarVisible}
         setSidebarVisible={setSidebarVisible}
-        activeLink={6}
+        activeLink={7}
       />
       {width > 816 && (
         <button

--- a/src/components/Forum.jsx
+++ b/src/components/Forum.jsx
@@ -792,7 +792,7 @@ export function Forum() {
       <SideBar
         sidebarVisible={sidebarVisible}
         setSidebarVisible={setSidebarVisible}
-        activeLink={10}
+        activeLink={11}
       />
       {width > 816 && (
         <button

--- a/src/components/ParentDashboard.jsx
+++ b/src/components/ParentDashboard.jsx
@@ -1439,7 +1439,7 @@ export  function ParentDashboard() {
 
   return (
     <div className={`flex h-screen dark:bg-[#111827]`}>
-        <SideBar sidebarVisible={sidebarVisible} setSidebarVisible={setSidebarVisible} activeLink={9}/>
+        <SideBar sidebarVisible={sidebarVisible} setSidebarVisible={setSidebarVisible} activeLink={10}/>
           {width > 816 && (
             <button
             onClick={toggleSidebar}

--- a/src/components/PartnerDashboard.jsx
+++ b/src/components/PartnerDashboard.jsx
@@ -1143,7 +1143,7 @@ Risk Level: [Low/Moderate/High]
       <SideBar
         sidebarVisible={sidebarVisible}
         setSidebarVisible={setSidebarVisible}
-        activeLink={5}
+        activeLink={6}
       />
       {width > 816 && (
         <button

--- a/src/components/SymptomAnalysis.jsx
+++ b/src/components/SymptomAnalysis.jsx
@@ -979,7 +979,7 @@ export function SymptomAnalysis() {
       <SideBar
         sidebarVisible={sidebarVisible}
         setSidebarVisible={setSidebarVisible}
-        activeLink={8}
+        activeLink={9}
       />
       {width > 816 && (
         <button


### PR DESCRIPTION

This pull request fixes an issue where the wrong sidebar menu item was being highlighted on certain pages. Specifically, when navigating to the **Parent's Dashboard**, the **Eve** menu item was incorrectly shown as active.


**Changes Made:**

* Corrected the index mapping for sidebar menu items to ensure the correct item is highlighted.
* Updated the index assigned to the **Parent's Dashboard** and **Eve** menu items so they reflect the correct active state based on the current route.
* No changes were made to the route-matching logic — only the index assignments were adjusted to fix the sidebar highlight issue.

**Before:**

* Visiting `/dashboard/parent` caused the **Eve** menu item to be highlighted.

**After:**

* The **Parent's Dashboard** menu item is correctly highlighted when on the `/dashboard/parent` route.

**Related Issue:**
Fixes #\<issue\_number> <!-- Replace with actual issue number -->

**Tested On:**

* [x] Parent's Dashboard
* [x] Eve Page
* [x] Other Necessary Pages